### PR TITLE
Fixes crash when setting top_value = nil

### DIFF
--- a/motion/project/slide_over_control.rb
+++ b/motion/project/slide_over_control.rb
@@ -142,7 +142,7 @@ class SlideOverControl < UIControl
     rmq(@top_view).remove if @top_view
     @top_view = value
 
-    rmq(@top_container).append(value)
+    rmq(@top_container).append(value) unless value.nil?
   end
 
   def slide_bar_height=(value)

--- a/spec/slide_over_control_spec.rb
+++ b/spec/slide_over_control_spec.rb
@@ -88,6 +88,14 @@ describe "slideover_controler" do
     it "should set a new top view" do
       @view.instance_variable_get("@top_view").should == @new_main_view
     end
+
+    it "should allow nil values for the top view" do
+      should.not.raise(StandardError) {
+        @view.top_view = nil
+      }
+
+      @view.instance_variable_get("@top_view").should == nil
+    end
   end
 
   describe "slide_bar_height=" do


### PR DESCRIPTION
Error when setting top_controller to `nil`: 

```
subviews.rb:196:in `create_view:': undefined method `<' for nil:NilClass (NoMethodError)
```
